### PR TITLE
Pass 404 errors to the browser instead of ignoring it

### DIFF
--- a/src/Nutsweb/LaravelPrerender/PrerenderMiddleware.php
+++ b/src/Nutsweb/LaravelPrerender/PrerenderMiddleware.php
@@ -173,6 +173,11 @@ class PrerenderMiddleware implements HttpKernelInterface
             // Return the Guzzle Response
             return $this->client->get('/' . urlencode($request->getUri()), compact('headers'));
         } catch (RequestException $exception) {
+            // Pass 404 errors to the browser assuming it comes from meta-tag prerender-status-code
+            if ($exception->getCode() == '404') {
+                \App::abort('404');
+            }
+
             // In case of an exception, we only throw the exception if we are in debug mode. Otherwise,
             // we return null and the handle() method will just pass the request to the next middleware
             // and we do not show a prerendered page.


### PR DESCRIPTION
I have an application where I send the meta tag `prerender-status-code` with 404 value, so that the Prerender-service will generate a 404-response. Unfortunately when this was done, the response from Prerender was ignored, bypassing the Prerender-service and sending a 200-response with the default catch-all template instead of the 404.

I can't find a reliable way of determining if the 404 is because the Prerender-service was not found or from the `prerender-status-code`-field, so in worst case if the case the Prerender-url changes, it will pass the 404 for all pages.

But I guess this is less likely than the application sending 404, and that we can assume it's from the meta tag.
