### PR TITLE
Fixes for SSL offloading with ELB 

### DIFF
--- a/src/PrerenderMiddleware.php
+++ b/src/PrerenderMiddleware.php
@@ -11,7 +11,6 @@ use GuzzleHttp\Client as Guzzle;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Response;
-use Log;
 
 class PrerenderMiddleware
 {

--- a/src/PrerenderMiddleware.php
+++ b/src/PrerenderMiddleware.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Client as Guzzle;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Response;
+use Log;
 
 class PrerenderMiddleware
 {
@@ -171,11 +172,14 @@ class PrerenderMiddleware
         if ($this->prerenderToken) {
             $headers['X-Prerender-Token'] = $this->prerenderToken;
         }
-
+	
+	$protocol = $request->isSecure() ? 'https' : 'http';
+	
         try {
             // Return the Guzzle Response
-            $originalUri = $request->getUri();
-            return $this->client->get($this->prerenderUri . '/' . urlencode($originalUri), compact('headers'));
+	    $host = $request->getHost();
+            $path = $request->Path();
+            return $this->client->get($this->prerenderUri . '/' . urlencode($protocol.'://'.$host.'/'.$path), compact('headers'));
         } catch (RequestException $exception) {
             // In case of an exception, we only throw the exception if we are in debug mode. Otherwise,
             // we return null and the handle() method will just pass the request to the next middleware


### PR DESCRIPTION
Https to http behind ELB has issues when trying to call prerender. 

This is a more generic solution compared to using the URL directly. 
We are validating the protocol between http and https using isSecure method. 

However for it to work correctly behind ELB, we also need to have a new middleware as described below 
https://gist.github.com/cjonstrup/5f0924007357f23cabe8

This should however be a generic solution. 