### PR TITLE
Added googlebot, bingbot, and yandex to list of user agents

### DIFF
--- a/config/prerender.php
+++ b/config/prerender.php
@@ -141,13 +141,10 @@
     */
 
     'crawler_user_agents' => [
-        // googlebot, yahoo, and bingbot are not in this list because
-        // we support _escaped_fragment_ and want to ensure people aren't
-        // penalized for cloaking.
-
-        // 'googlebot',
-        // 'yahoo',
-        // 'bingbot',
+        'googlebot',
+        'yahoo',
+        'bingbot',
+        'yandex',
         'baiduspider',
         'facebookexternalhit',
         'twitterbot',


### PR DESCRIPTION
Google now supports "Dynamic Rendering" where you can serve them back a prerendered page. Since they will stop crawling `?_escaped_fragment_=` URLs, this change will continue to allow Google to crawl prerendered pages.

More information can be found here: https://prerender.io/documentation/google-support