### PR TITLE
Trailing slashes fixed (URL should have end slashes in SEO)

### DIFF
--- a/src/PrerenderMiddleware.php
+++ b/src/PrerenderMiddleware.php
@@ -200,12 +200,10 @@ class PrerenderMiddleware
     
         try {
             // Return the Guzzle Response
-        $host = $request->getHost();
-            $path = $request->Path();
-            // Fix "//" 404 error
-            if ($path == "/") {
-                $path = "";
-            }
+            $host = $request->getHost();
+            // Set path to request URI for fix trailing slashes (URL should have end slashes in Seo)
+            $path = $request->getRequestUri();
+
             return $this->client->get($this->prerenderUri . '/' . urlencode($protocol.'://'.$host.'/'.$path), compact('headers'));
         } catch (RequestException $exception) {
             if(!$this->returnSoftHttpCodes && !empty($exception->getResponse()) && $exception->getResponse()->getStatusCode() == 404) {


### PR DESCRIPTION
URL should have end slashes in SEO.
URL without end slash should redirect with 301 status to URL with end slash.
E.g. **https://github.com/jeroennoten/Laravel-Prerender** redirect to **https://github.com/jeroennoten/Laravel-Prerender/**
So `$path` changed to request URI.
What's the use of this codes?
```
if ($path == "/") {
      $path = "";
}
```
I think It just removes end slash from home page that It's not good for Seo