### PR TITLE
Make location header case insensitive

### DIFF
--- a/src/PrerenderMiddleware.php
+++ b/src/PrerenderMiddleware.php
@@ -118,7 +118,8 @@ class PrerenderMiddleware
                 $statusCode = $prerenderedResponse->getStatusCode();
 
                 if (!$this->returnSoftHttpCodes && $statusCode >= 300 && $statusCode < 400) {
-                    return Redirect::to($prerenderedResponse->getHeaders()["Location"][0], $statusCode);
+                    $headers = $prerenderedResponse->getHeaders();
+                    return Redirect::to(array_change_key_case($headers, CASE_LOWER)["location"][0], $statusCode);
                 }
 
                 return $this->buildSymfonyResponseFromGuzzleResponse($prerenderedResponse);


### PR DESCRIPTION
Some software returns the HTTP "Location" header in variations of case sensitivities.
For example, https://github.com/prerender/prerender appears to returning the header as "location" all lower case. This commit will convert the array keys to lower case then always compare to "location" to make it case insensitive.